### PR TITLE
Add a warning for geoglows v1

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -12,7 +12,7 @@ requirements:
     channels:
       - conda-forge
     packages:
-      - geoglows>=0.20
+      - geoglows==0.27.1
       - xmltodict
       - pandas
       - requests

--- a/tethysapp/geoglows_hydroviewer/public/css/main.css
+++ b/tethysapp/geoglows_hydroviewer/public/css/main.css
@@ -8,8 +8,17 @@
     height: 100%;
 }
 
+#warning_modal .modal-dialog {
+    top: 30%;
+}
+
+#warning_modal .modal-dialog .modal-content {
+    color: #856404;
+    background-color: #fff3cd;
+}
+
 #chart_modal .modal-dialog {
-    width: 80%
+    width: 80%;
 }
 
 #app-navigation li {

--- a/tethysapp/geoglows_hydroviewer/public/js/geoglows_hydroviewer_core.js
+++ b/tethysapp/geoglows_hydroviewer/public/js/geoglows_hydroviewer_core.js
@@ -11,6 +11,10 @@ let mapMarker = null
 let controlsObj
 let SelectedSegment = L.geoJSON(false, { weight: 5, color: "#00008b" }).addTo(mapObj)
 
+$(document).ready(function() {
+    $('#warning_modal').modal('show');
+})
+
 const basemapsJson = {
     "ESRI Topographic": L.esri.basemapLayer("Topographic").addTo(mapObj),
     "ESRI Terrain": L.layerGroup([

--- a/tethysapp/geoglows_hydroviewer/templates/geoglows_hydroviewer/geoglows_hydroviewer.html
+++ b/tethysapp/geoglows_hydroviewer/templates/geoglows_hydroviewer/geoglows_hydroviewer.html
@@ -37,6 +37,24 @@
 {% endblock %}
 
 {% block after_app_content %}
+  <div class="modal fade" id="warning_modal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Warning</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p>This app displays the data from GEOGLOWS Version 1, which will continue to be available until April, 2025. For more information join our Google Group and Mailing List 
+            <a href=" https://groups.google.com/g/geoglows-streamflow" target="_blank">Here</a>.</p>
+          <p>You can interact with GEOGLOWS Version 2 data from the following beta apps: 
+            <a href="https://hydroviewer.geoglows.org/">https://hydroviewer.geoglows.org</a> and
+            <a href="https://beta.apps.geoglows.org/apps/hydroviewer/">https://beta.apps.geoglows.org/apps/hydroviewer</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
   {# Chart Modals #}
   <div class="modal fade" id="chart_modal" role="dialog">
     <div class="modal-dialog modal-xl" role="document">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0d59c03a-93b4-42d2-89d2-189e7c18abbd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a warning modal to inform users about the availability of GEOGLOWS Version 1 data until April 2025.
- **Enhancements**
	- Updated the `geoglows` package version to ensure compatibility.
	- Added new styles for the warning modal to improve user interface.
	- Implemented a jQuery function to display the warning modal upon application load.
- **Bug Fixes**
	- Corrected formatting in the styles for the chart modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->